### PR TITLE
Add Lux, fix Secret project type and bastille date

### DIFF
--- a/old-python-script-and-data/dataSando.csv
+++ b/old-python-script-and-data/dataSando.csv
@@ -52,10 +52,11 @@ Sunreach,2021,6,40000,3
 ReDawn,2021,8,40000,3
 Cytonics,2021,10,150000,3
 Evershore,2021,12,50000,3
-Bastille vs. the Evil Librarians,2022,8,70000,4
+Lux,2022,07,143520,5
+Bastille vs. the Evil Librarians,2022,9,70000,4
 The Lost Metal,2022,10,200000,0
 Secret Project #1,2023,1,200000,2
-Secret Project #2,2023,4,200000,2
+Secret Project #2,2023,4,200000,8
 Secret Project #3,2023,7,200000,2
 Secret Project #3,2023,7,200000,2
 Defiant,2023,8.5,140000,3


### PR DESCRIPTION
Sources for Bastille and Lux dates
https://www.brandonsanderson.com/state-of-the-sanderson-2021/
July: Lux (Reckoners) ebook, Alcatraz 3 paperback
September: Bastille vs. the Evil Librarians (Alcatraz 6), in hardcover, ebook, and audio; Alcatraz 5 paperback

Source for the size of Lux (to be updated i think)
https://howlongtoread.com/books/15740821/Lux

One of the 4 secret project is non-cosmere as stated in https://www.youtube.com/watch?v=6a-k6eaT-jQ
I assume it's the second one because the book cover show earth on it(europe, africa), and no cosmere book can contains earth